### PR TITLE
Feat: Launch game dialog, several bug fixes

### DIFF
--- a/ChaosInitiative.SDKLauncher/App.axaml.cs
+++ b/ChaosInitiative.SDKLauncher/App.axaml.cs
@@ -15,12 +15,12 @@ namespace ChaosInitiative.SDKLauncher
 
         public override void OnFrameworkInitializationCompleted()
         {
-            if (!(ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop))
+            if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
                 return;
 
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(),
+                DataContext = new MainWindowViewModel()
             };
 
             base.OnFrameworkInitializationCompleted();

--- a/ChaosInitiative.SDKLauncher/Models/AppConfig.cs
+++ b/ChaosInitiative.SDKLauncher/Models/AppConfig.cs
@@ -10,7 +10,7 @@ namespace ChaosInitiative.SDKLauncher.Models
     {
         private const string ConfigName = "config.json";
 
-        private static readonly JsonSerializerOptions ConfigJsonSerializerOptions = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions ConfigJsonSerializerOptions = new()
         {
             WriteIndented = true
         };

--- a/ChaosInitiative.SDKLauncher/Models/Profile.cs
+++ b/ChaosInitiative.SDKLauncher/Models/Profile.cs
@@ -17,9 +17,9 @@ namespace ChaosInitiative.SDKLauncher.Models
         
         public static Profile GetDefaultProfile()
         {
-            return new Profile
+            return new()
             {
-                Name = "P2CE - Default",
+                Name = "P2:CE - Default",
                 Mod = new Mod
                 {
                     Name = "Portal 2: Community Edition",

--- a/ChaosInitiative.SDKLauncher/Program.cs
+++ b/ChaosInitiative.SDKLauncher/Program.cs
@@ -4,7 +4,7 @@ using Avalonia.ReactiveUI;
 
 namespace ChaosInitiative.SDKLauncher
 {
-    static class Program
+    internal static class Program
     {
         // Initialization code. Don't use any Avalonia, third-party APIs or any
         // SynchronizationContext-reliant code before AppMain is called: things aren't initialized

--- a/ChaosInitiative.SDKLauncher/Util/MountUtil.cs
+++ b/ChaosInitiative.SDKLauncher/Util/MountUtil.cs
@@ -7,14 +7,12 @@ namespace ChaosInitiative.SDKLauncher.Util
 {
     public static class MountUtil
     {
-        
-
         public static bool IsValidSearchPath(string searchPath)
         {
             return File.Exists($"{searchPath}/gameinfo.txt");
         }
 
-        public static readonly FileDialogFilter GameInfoFileFilter = new FileDialogFilter()
+        public static readonly FileDialogFilter GameInfoFileFilter = new()
         {
             Name = "Game Info",
             Extensions = new List<string>
@@ -23,7 +21,7 @@ namespace ChaosInitiative.SDKLauncher.Util
             }
         };
 
-        private static Dictionary<PlatformID, string> PlatformNames = new()
+        private static readonly Dictionary<PlatformID, string> PlatformNames = new()
         {
             { PlatformID.Win32NT, "win" },
             { PlatformID.MacOSX, "osx" },

--- a/ChaosInitiative.SDKLauncher/Util/ReactiveCommandUtil.cs
+++ b/ChaosInitiative.SDKLauncher/Util/ReactiveCommandUtil.cs
@@ -7,7 +7,7 @@ namespace ChaosInitiative.SDKLauncher.Util
     {
         public static ReactiveCommand<Unit, Unit> CreateEmpty()
         {
-            return ReactiveCommand.Create(() => { });
+            return ReactiveCommand.Create(() => {});
         }
     }
 }

--- a/ChaosInitiative.SDKLauncher/Util/ToolsLaunchException.cs
+++ b/ChaosInitiative.SDKLauncher/Util/ToolsLaunchException.cs
@@ -4,14 +4,11 @@ namespace ChaosInitiative.SDKLauncher.Util
 {
     public class ToolsLaunchException : Exception
     {
-
-        private string _message;
-        
         public ToolsLaunchException(string message)
         {
-            _message = message;
+            Message = message;
         }
 
-        public override string Message => _message;
+        public override string Message { get; }
     }
 }

--- a/ChaosInitiative.SDKLauncher/Util/ToolsUtil.cs
+++ b/ChaosInitiative.SDKLauncher/Util/ToolsUtil.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace ChaosInitiative.SDKLauncher.Util
 {
-    public class ToolsUtil
+    public static class ToolsUtil
     {
         public static Process LaunchTool(string binDirectory, string executableName, string args = "", bool windowsOnly = false, string workingDir = null)
         {

--- a/ChaosInitiative.SDKLauncher/ViewLocator.cs
+++ b/ChaosInitiative.SDKLauncher/ViewLocator.cs
@@ -11,17 +11,14 @@ namespace ChaosInitiative.SDKLauncher
 
         public IControl Build(object data)
         {
-            var name = data.GetType().FullName.Replace("ViewModel", "View");
+            string name = data.GetType().FullName.Replace("ViewModel", "View");
             var type = Type.GetType(name);
 
             if (type != null)
             {
                 return (Control)Activator.CreateInstance(type);
             }
-            else
-            {
-                return new TextBlock { Text = "Not Found: " + name };
-            }
+            return new TextBlock { Text = "Not Found: " + name };
         }
 
         public bool Match(object data)

--- a/ChaosInitiative.SDKLauncher/ViewModels/AddMountViewModel.cs
+++ b/ChaosInitiative.SDKLauncher/ViewModels/AddMountViewModel.cs
@@ -6,7 +6,11 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
 {
     public class AddMountViewModel : ReactiveObject
     {
-        
+        public AddMountViewModel(ReactiveCommand<Unit, Unit> onClickAdd)
+        {
+            OnClickAdd = onClickAdd;
+        }
+
         public bool UseAppId { get; set; } = true;
         public Mount Mount { get; } = new ();
 

--- a/ChaosInitiative.SDKLauncher/ViewModels/LaunchGameWindowViewModel.cs
+++ b/ChaosInitiative.SDKLauncher/ViewModels/LaunchGameWindowViewModel.cs
@@ -1,0 +1,22 @@
+using System.Reactive;
+using System.Reactive.Disposables;
+using ReactiveUI;
+
+namespace ChaosInitiative.SDKLauncher.ViewModels
+{
+    public class LaunchGameWindowViewModel : ReactiveObject, IActivatableViewModel
+    {
+        public ViewModelActivator Activator { get; }
+        
+        public ReactiveCommand<Unit, Unit> OnClickLaunchGame { get; set; }
+
+        public LaunchGameWindowViewModel()
+        {
+            Activator = new ViewModelActivator();
+
+            this.WhenActivated(disposable => {Disposable.Create(() => {}).DisposeWith(disposable);});
+
+            OnClickLaunchGame = ReactiveCommand.Create(() => {});
+        }
+    }
+}

--- a/ChaosInitiative.SDKLauncher/ViewModels/MainWindowViewModel.cs
+++ b/ChaosInitiative.SDKLauncher/ViewModels/MainWindowViewModel.cs
@@ -53,7 +53,7 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
 
             Activator = new ViewModelActivator();
             
-            this.WhenActivated((CompositeDisposable disposable) =>
+            this.WhenActivated((disposable) =>
             {
                 Disposable.Create(() =>
                 {
@@ -92,10 +92,10 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
 
         public void CreateProfile()
         {
-            Profile profile = Profile.GetDefaultProfile();
+            var profile = Profile.GetDefaultProfile();
             
-            string profileName = "";
-            for (int i = 1; i <= 10; i++)
+            var profileName = "";
+            for (var i = 1; i <= 10; i++)
             {
                 if (i == 10)
                     return;

--- a/ChaosInitiative.SDKLauncher/ViewModels/MainWindowViewModel.cs
+++ b/ChaosInitiative.SDKLauncher/ViewModels/MainWindowViewModel.cs
@@ -38,8 +38,7 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
 
         public ReactiveCommand<Unit, Unit> OnClickOpenHammer { get; }
         public ReactiveCommand<Unit, Unit> OnClickOpenModelViewer { get; }
-        public ReactiveCommand<Unit, Unit> OnClickLaunchGame { get; }        
-        public ReactiveCommand<Unit, Unit> OnClickLaunchToolsMode { get; }        
+        public ReactiveCommand<Unit, Unit> OnClickLaunchGame { get; }    
         public ReactiveCommand<Unit, Unit> OnClickCreateMod { get; }
         public ReactiveCommand<Unit, Unit> OnClickEditProfile { get; }
         public ReactiveCommand<Unit, Unit> OnClickCreateProfile { get; }
@@ -53,7 +52,7 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
 
             Activator = new ViewModelActivator();
             
-            this.WhenActivated((disposable) =>
+            this.WhenActivated(disposable =>
             {
                 Disposable.Create(() =>
                 {
@@ -71,11 +70,10 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
             };
 
             OnClickCreateMod = ReactiveCommandUtil.CreateEmpty();
-            OnClickOpenHammer = ReactiveCommand.Create(() => { }, Observable.Return(OperatingSystem.IsWindows()));
+            OnClickOpenHammer = ReactiveCommand.Create(() => { }, Observable.Return(OperatingSystem.IsWindows() || OperatingSystem.IsLinux()));
             OnClickOpenModelViewer = ReactiveCommand.Create(() => { }, Observable.Return(OperatingSystem.IsWindows()));
 
             OnClickLaunchGame = ReactiveCommandUtil.CreateEmpty();
-            OnClickLaunchToolsMode = ReactiveCommandUtil.CreateEmpty();
             
             OnClickCreateProfile = ReactiveCommand.Create(CreateProfile);
             OnClickDeleteProfile = ReactiveCommand.Create(DeleteProfile);
@@ -120,6 +118,5 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
         {
             
         }
-
     }
 }

--- a/ChaosInitiative.SDKLauncher/ViewModels/NotificationViewModel.cs
+++ b/ChaosInitiative.SDKLauncher/ViewModels/NotificationViewModel.cs
@@ -14,7 +14,7 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
         {
             Activator = new ViewModelActivator();
             
-            this.WhenActivated((CompositeDisposable disposable) =>
+            this.WhenActivated((disposable) =>
             {
                 Disposable.Create(() =>
                 {

--- a/ChaosInitiative.SDKLauncher/ViewModels/ProfileConfigViewModel.cs
+++ b/ChaosInitiative.SDKLauncher/ViewModels/ProfileConfigViewModel.cs
@@ -27,7 +27,7 @@ namespace ChaosInitiative.SDKLauncher.ViewModels
 
             Profile = profile;
             
-            this.WhenActivated((CompositeDisposable disposable) =>
+            this.WhenActivated((disposable) =>
             {
                 Disposable.Create(() =>
                 {

--- a/ChaosInitiative.SDKLauncher/Views/CreateModWindow.axaml
+++ b/ChaosInitiative.SDKLauncher/Views/CreateModWindow.axaml
@@ -20,23 +20,8 @@
 		</Style>
 	</Window.Styles>
 
-	<Grid>
-
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*"/>
-			<ColumnDefinition Width="*"/>
-		</Grid.ColumnDefinitions>
-		
-		<Grid.RowDefinitions>
-			<RowDefinition Height="auto"/>
-			<RowDefinition Height="auto"/>
-		</Grid.RowDefinitions>
-
-
+	<Grid RowDefinitions="auto,auto" ColumnDefinitions="*,*">
 		<TextBox Grid.Row="0" Grid.Column="0" Watermark="Mod Name"/>
 		<TextBox Grid.Row="0" Grid.Column="1" Watermark="Namespace name"/>
-		
-	
 	</Grid>
-	
 </Window>

--- a/ChaosInitiative.SDKLauncher/Views/LaunchGameWindow.axaml
+++ b/ChaosInitiative.SDKLauncher/Views/LaunchGameWindow.axaml
@@ -1,0 +1,32 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewModels="clr-namespace:ChaosInitiative.SDKLauncher.ViewModels"
+        mc:Ignorable="d"
+        x:Class="ChaosInitiative.SDKLauncher.Views.LaunchGameWindow"
+		Width="300" Height="450"
+		CanResize="False"
+		Icon="/Assets/p2ce_logo.png"
+        Title="Launch Game">
+
+	<Design.DataContext>
+		<viewModels:LaunchGameWindowViewModel/>
+	</Design.DataContext>
+
+	<Window.Styles>
+		<Style Selector="Button,ComboBox,TextBox,TextBlock">
+			<Setter Property="Margin" Value="4"/>
+		</Style>
+	</Window.Styles>
+
+	<Grid RowDefinitions="auto,auto,auto,auto,auto,auto,auto,*" ColumnDefinitions="*,*">
+		<TextBlock Grid.Row="0">Launch Options:</TextBlock>
+		<CheckBox Grid.Row="1" Grid.Column="0" x:Name="ToolsMode">Tools Mode</CheckBox>
+		<CheckBox Grid.Row="2" Grid.Column="0" x:Name="Console">Enable Console</CheckBox>
+		<CheckBox Grid.Row="3" Grid.Column="0" x:Name="DeveloperMode">Developer Mode</CheckBox>
+		<CheckBox Grid.Row="4" Grid.Column="0" x:Name="LegacyUi">Legacy UI</CheckBox>
+		<CheckBox Grid.Row="5" Grid.Column="0" x:Name="GraphicsApi">DirectX 11</CheckBox>
+		<Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" MinHeight="32" x:Name="LaunchGameButton">Launch Game</Button>
+	</Grid>
+</Window>

--- a/ChaosInitiative.SDKLauncher/Views/LaunchGameWindow.axaml.cs
+++ b/ChaosInitiative.SDKLauncher/Views/LaunchGameWindow.axaml.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
+using ChaosInitiative.SDKLauncher.Models;
+using ChaosInitiative.SDKLauncher.Util;
+using ChaosInitiative.SDKLauncher.ViewModels;
+using ReactiveUI;
+
+namespace ChaosInitiative.SDKLauncher.Views
+{
+    public class LaunchGameWindow : ReactiveWindow<LaunchGameWindowViewModel>
+    {
+        protected CheckBox ToolsModeCheckBox => this.FindControl<CheckBox>("ToolsMode");
+        protected CheckBox ConsoleCheckBox => this.FindControl<CheckBox>("Console");
+        protected CheckBox DeveloperCheckBox => this.FindControl<CheckBox>("DeveloperMode");
+        protected CheckBox GraphicsApiCheckBox => this.FindControl<CheckBox>("GraphicsApi");
+        protected CheckBox LegacyUiCheckBox => this.FindControl<CheckBox>("LegacyUi");
+        private Button LaunchGameButton => this.FindControl<Button>("LaunchGameButton");
+        
+        private readonly Profile _currentProfile;
+
+        // Apparently used by VS Designer
+        public LaunchGameWindow() : this(Profile.GetDefaultProfile())
+        {
+        }
+        
+        public LaunchGameWindow(Profile currentProfile)
+        {
+            AvaloniaXamlLoader.Load(this);
+            this.AttachDevTools();
+
+            ViewModel = new LaunchGameWindowViewModel();
+            
+            this.WhenActivated(disposables =>
+            {
+                ViewModel.OnClickLaunchGame = ReactiveCommand.Create(LaunchGame);
+                
+                this.BindCommand(ViewModel, 
+                    vm => vm.OnClickLaunchGame, 
+                    v => v.LaunchGameButton).DisposeWith(disposables);
+            });
+            
+            _currentProfile = currentProfile;
+        }
+        
+        private void LaunchGame()
+        {
+            string binDir = _currentProfile.Mod.Mount.BinDirectory;
+            string executableName = _currentProfile.Mod.ExecutableName;
+            string gameRootPath = _currentProfile.Mod.Mount.MountPath;
+            
+            if (OperatingSystem.IsWindows())
+            {
+                executableName += ".exe";
+            }
+            else if (OperatingSystem.IsLinux())
+            {
+                executableName += ".sh";
+            }
+
+            string binPath = Path.Combine(binDir, executableName);
+
+            // See if the binary is in bin folder
+            if (!File.Exists(binPath))
+            {
+                // Not in a chaos game. Try to find it in game root.
+                binPath = Path.Combine(gameRootPath, executableName);
+                if (!File.Exists(binPath))
+                {
+                    var dialog = new NotificationDialog($"Unable to find game binary '{binPath}'");
+                    dialog.ShowDialog(this);
+                    return;
+                }
+            }
+
+            var args = $"{_currentProfile.Mod.LaunchArguments} -game {_currentProfile.Mod.Mount.PrimarySearchPath}";
+            if (!string.IsNullOrWhiteSpace(_currentProfile.AdditionalMount.MountPath))
+            {
+                args += $" -mountmod \"{Path.Combine(_currentProfile.AdditionalMount.MountPath, _currentProfile.AdditionalMount.PrimarySearchPath)}\"";
+            }
+            if (ToolsModeCheckBox.IsChecked != null && ToolsModeCheckBox.IsChecked.Value && !args.Contains("-tools"))
+                args += " -tools";
+            if (LegacyUiCheckBox.IsChecked != null && LegacyUiCheckBox.IsChecked.Value && !args.Contains("-legacyui"))
+                args += " -legacyui";
+            if (GraphicsApiCheckBox.IsChecked != null && GraphicsApiCheckBox.IsChecked.Value && !args.Contains("-shaderapi"))
+                args += " -shaderapi shaderapidx11";
+            if (ConsoleCheckBox.IsChecked != null && ConsoleCheckBox.IsChecked.Value && !args.Contains("-console"))
+                args += " -console";
+            if (DeveloperCheckBox.IsChecked != null && DeveloperCheckBox.IsChecked.Value && !args.Contains("-dev"))
+                args += " -dev";
+
+            try
+            {
+                ToolsUtil.LaunchTool(binDir, executableName, args, false, gameRootPath);
+            }
+            catch (ToolsLaunchException e)
+            {
+                var dialog = new NotificationDialog(e.Message);
+                dialog.ShowDialog(this);
+            }
+            
+            Close();
+        }
+    }
+}

--- a/ChaosInitiative.SDKLauncher/Views/MainWindow.axaml
+++ b/ChaosInitiative.SDKLauncher/Views/MainWindow.axaml
@@ -22,17 +22,14 @@
             
             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">Tools:</TextBlock>
             
-            <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" x:Name="OpenHammerButton"
+            <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" MinHeight="32" x:Name="OpenHammerButton"
                     Command="{Binding OnClickOpenHammer}">Hammer World Editor</Button>
             
-            <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" x:Name="OpenModelViewerButton"
+            <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" MinHeight="32" x:Name="OpenModelViewerButton"
                     Command="{Binding OnClickOpenModelViewer}">Model Viewer</Button>
             
-            <Button Grid.Row="3" Grid.Column="0" 
+            <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" MinHeight="32" x:Name="OpenGameButton"
                     Command="{Binding OnClickLaunchGame}">Launch Game</Button>
-            
-            <Button Grid.Row="3" Grid.Column="1"
-                    Command="{Binding OnClickLaunchToolsMode}">Launch Tools Mode</Button>
             <!--
             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">Mods:</TextBlock>
             <Button Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" x:Name="CreateModButton"

--- a/ChaosInitiative.SDKLauncher/Views/MainWindow.axaml
+++ b/ChaosInitiative.SDKLauncher/Views/MainWindow.axaml
@@ -18,108 +18,60 @@
     </Design.DataContext>
 
     <DockPanel>
-        <Grid DockPanel.Dock="Top"
-              VerticalAlignment="Top">
+        <Grid DockPanel.Dock="Top" VerticalAlignment="Top" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto">
             
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">Tools:</TextBlock>
             
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-
-            <TextBlock Grid.Row="0" 
-                       Grid.Column="0" 
-                       Grid.ColumnSpan="2">Tools:</TextBlock>
-            <Button Grid.Row="1" 
-                    Grid.Column="0" 
-                    Grid.ColumnSpan="2" x:Name="OpenHammerButton" Command="{Binding OnClickOpenHammer}">Hammer World Editor</Button>
+            <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" x:Name="OpenHammerButton"
+                    Command="{Binding OnClickOpenHammer}">Hammer World Editor</Button>
             
-            <Button Grid.Row="2" 
-                    Grid.Column="0" 
-                    Grid.ColumnSpan="2" x:Name="OpenModelViewerButton" Command="{Binding OnClickOpenModelViewer}">Model Viewer</Button>
+            <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" x:Name="OpenModelViewerButton"
+                    Command="{Binding OnClickOpenModelViewer}">Model Viewer</Button>
             
-            <Button Grid.Row="3" 
-                    Grid.Column="0" 
+            <Button Grid.Row="3" Grid.Column="0" 
                     Command="{Binding OnClickLaunchGame}">Launch Game</Button>
-            <Button Grid.Row="3" 
-                    Grid.Column="1"
+            
+            <Button Grid.Row="3" Grid.Column="1"
                     Command="{Binding OnClickLaunchToolsMode}">Launch Tools Mode</Button>
-<!--
-            <TextBlock>Mods:</TextBlock>
-            <Button x:Name="CreateModButton" Command="{Binding OnClickCreateMod}">Create Mod</Button>
+            <!--
+            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">Mods:</TextBlock>
+            <Button Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" x:Name="CreateModButton"
+                    Command="{Binding OnClickCreateMod}">Create Mod</Button>
             -->
         </Grid>
 
-        <Grid DockPanel.Dock="Bottom" VerticalAlignment="Bottom">
+        <Grid DockPanel.Dock="Bottom" VerticalAlignment="Bottom" RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,Auto,Auto,*">
 
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <TextBlock Grid.Row="0"
-                       Grid.Column="0"
-                       Grid.ColumnSpan="4">
+            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4">
                 Workspace Profiles
             </TextBlock>
 
-            <Button x:Name="CreateProfileButton"
-                    Grid.Row="1"
-                    Grid.Column="0"
-                    Classes="IconButton"
+            <Button x:Name="CreateProfileButton" Grid.Row="1" Grid.Column="0" Classes="IconButton"
                     Command="{Binding OnClickCreateProfile}">
                 <Image Source="/Assets/plus_math_16px.png" Classes="IconImage"/>
             </Button>
-            <Button x:Name="DeleteProfileButton"
-                    Grid.Row="1"
-                    Grid.Column="1"
-                    Classes="IconButton"
+            <Button x:Name="DeleteProfileButton" Grid.Row="1" Grid.Column="1" Classes="IconButton"
                     Command="{Binding OnClickDeleteProfile}">
                 <Image Source="/Assets/subtract_16px.png" Classes="IconImage"/>
             </Button>
-            <Button x:Name="EditProfileButton"
-                    Grid.Row="1"
-                    Grid.Column="2"
-                    Classes="IconButton"
+            <Button x:Name="EditProfileButton" Grid.Row="1" Grid.Column="2" Classes="IconButton"
                     Command="{Binding OnClickEditProfile}">
                 <Image Source="/Assets/edit_16px.png" Classes="IconImage"/>
             </Button>
-            <StackPanel Grid.Row="1"
-                        Grid.Column="3"
-                        HorizontalAlignment="Right"
-                        Orientation="Horizontal">
-                
-                <Image Source="/Assets/checkmark_16px.png" 
-                       Classes="IconImage" 
+            
+            <StackPanel Grid.Row="1" Grid.Column="3" HorizontalAlignment="Right" Orientation="Horizontal">
+                <Image Source="/Assets/checkmark_16px.png" Classes="IconImage" 
                        IsVisible="{Binding ShowSaveConfirmation}"
                        Margin="0 0 6 0"/>
                 
-                <Button x:Name="SaveConfigButton"
-                        Classes="IconButton"
+                <Button x:Name="SaveConfigButton" Classes="IconButton"
                         Command="{Binding OnClickSaveConfig}"
                         IsVisible="{Binding !ShowSaveConfirmation}">
                     <Image Source="/Assets/save_16px.png" Classes="IconImage"/>
                 </Button>
             </StackPanel>
 
-            <ComboBox x:Name="ProfilesBox"
-                      Grid.Row="2"
-                      Grid.Column="0"
-                      Grid.ColumnSpan="4"
+            <ComboBox x:Name="ProfilesBox" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4"
                       Items="{Binding Profiles}"
                       SelectedIndex="{Binding CurrentProfileIndex}">
                 <ComboBox.ItemTemplate>
@@ -128,8 +80,6 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-
         </Grid>
     </DockPanel>
-
 </Window>

--- a/ChaosInitiative.SDKLauncher/Views/MainWindow.axaml.cs
+++ b/ChaosInitiative.SDKLauncher/Views/MainWindow.axaml.cs
@@ -16,7 +16,6 @@ namespace ChaosInitiative.SDKLauncher.Views
 {
     public class MainWindow : ReactiveWindow<MainWindowViewModel>
     {
-
         protected Button EditProfileButton => this.FindControl<Button>("EditProfileButton");
         protected Button OpenToolsModeButton => this.FindControl<Button>("OpenToolsModeButton");
         protected Button OpenGameButton => this.FindControl<Button>("OpenGameButton");
@@ -65,7 +64,10 @@ namespace ChaosInitiative.SDKLauncher.Views
 
                 ViewModel.OnClickLaunchGame.Subscribe(_ => LaunchGame(false));
                 ViewModel.OnClickLaunchToolsMode.Subscribe(_ => LaunchGame(true));
-
+                
+                // This sets up all the correct paths to use to launch the tools and game
+                // Note: This looks like it won't work here, but it really does, try it out
+                InitializeSteamClient((uint)ViewModel.CurrentProfile.Mod.Mount.AppId);
             });
 
             Closing += OnClosing;
@@ -88,8 +90,6 @@ namespace ChaosInitiative.SDKLauncher.Views
 
         private void LaunchGame(bool toolsMode)
         {
-            InitializeSteamClient((uint)ViewModel.CurrentProfile.Mod.Mount.AppId);
-
             string binDir = ViewModel.CurrentProfile.Mod.Mount.BinDirectory;
             string executableName = ViewModel.CurrentProfile.Mod.ExecutableName;
             string gameRootPath = ViewModel.CurrentProfile.Mod.Mount.MountPath;
@@ -136,12 +136,16 @@ namespace ChaosInitiative.SDKLauncher.Views
                            false,
                            gameRootPath,
                            binDir);
-            } catch(Exception) { }
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
 
         private void ShowNotification(string message)
         {
-            NotificationDialog dialog = new NotificationDialog(message);
+            var dialog = new NotificationDialog(message);
             dialog.ShowDialog(this);
         }
 
@@ -152,16 +156,15 @@ namespace ChaosInitiative.SDKLauncher.Views
 
         private void EditProfile()
         {
-            ProfileConfigWindow profileConfigWindow = new ProfileConfigWindow
+            var profileConfigWindow = new ProfileConfigWindow
             {
                 DataContext = new ProfileConfigViewModel(ViewModel.CurrentProfile)
             };
             profileConfigWindow.ShowDialog(this);
         }
 
-        private void InitializeSteamClient(uint appId)
+        private static void InitializeSteamClient(uint appId)
         {
-            // Init steam stuff, with the specified app
             if (Application.Current.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
             {
                 throw new Exception("Wrong application lifetime, contact a developer");

--- a/ChaosInitiative.SDKLauncher/Views/NotificationDialog.axaml
+++ b/ChaosInitiative.SDKLauncher/Views/NotificationDialog.axaml
@@ -9,6 +9,7 @@
         MinWidth="200"
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
+        Icon="/Assets/p2ce_logo.png"
         Title="Notification">
 
     <Design.DataContext>

--- a/ChaosInitiative.SDKLauncher/Views/NotificationDialog.axaml.cs
+++ b/ChaosInitiative.SDKLauncher/Views/NotificationDialog.axaml.cs
@@ -28,7 +28,7 @@ namespace ChaosInitiative.SDKLauncher.Views
 
             this.WhenActivated(disposable =>
             {
-                ViewModel.OnClickClose = ReactiveCommand.Create(Close).DisposeWith(disposable);
+                ViewModel.OnClickClose = ReactiveCommand.Create(Close);
 
                 this.BindCommand(ViewModel, 
                                  vm => vm.OnClickClose, 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The tool can be used to launch tools like hammer or the game itself and manage c
 
 ### Installation
 
-SDKLauncher is shipped with Portal 2: Community Edition on Steam. Since this is a standalone program in its own right, precompiled binaries can be downloaded in the GitHub Releases section
+SDKLauncher is shipped with Portal 2: Community Edition on Steam. Since this is a standalone program in its own right, precompiled binaries can be downloaded in the GitHub Releases section.
 
 ### Currently in-development!
 


### PR DESCRIPTION
For the SDK Launcher:

- The Launch Game button now has a submenu with common console arguments
- Tools can be ran without running the game first
- The notification dialog no longer crashes the application when closed
- Launching Hammer works

![image](https://user-images.githubusercontent.com/26600014/117556503-b289d780-b037-11eb-8056-01f6c6c2b206.png)